### PR TITLE
bugfix: logo not being displayed correctly

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -14,7 +14,7 @@ const AppRoute = () => (
     <Router>
         <div>
             <div className="banner">
-                <img src={ScyllaBannerImage} alt="banner" />
+                <img src={ScyllaBannerImage.replace('..', '')} alt="banner" />
             </div>
             <ul className="navigation">
                 <li><NavLink exact={true} to="/">Proxy IP List</NavLink></li>


### PR DESCRIPTION
This is a dirty fix to address the problem in which `parcel` currently
doesn't resolve relative path correctly.
i.e.,
"./images/scylla_banner.png" will get resolved into
"/assets/../scylla_banner.8d51f6c4.png" where it should be
"/assets/scylla_banner.8d51f6c4.png"
Until parcel upstream fix its bug, this patch will have to stay.

