### PR TITLE
docs: fix simple typo, serveer -> server

### DIFF
--- a/scylla/cli.py
+++ b/scylla/cli.py
@@ -55,7 +55,7 @@ def main(args) -> int:
         if not get_config('skip_scheduler'):
             s.start()
 
-        # forward proxy serveer
+        # forward proxy server
         if not get_config('no_forward_proxy_server'):
             start_forward_proxy_server_non_blocking()
 


### PR DESCRIPTION
There is a small typo in scylla/cli.py.

Should read `server` rather than `serveer`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md