### PR TITLE
Fix the 'usproxy' KeyError

### DIFF
--- a/scylla/providers/proxy_scraper_provider.py
+++ b/scylla/providers/proxy_scraper_provider.py
@@ -16,10 +16,10 @@ class ProxyScraperProvider(BaseProvider):
 
         text = document.html()
         json_object = json.loads(text)
-        if not json_object or type(json_object['usproxy']) != list:
+        if not json_object or type(json_object['proxynova']) != list:
             return ip_list
 
-        for ip_port in json_object['usproxy']:
+        for ip_port in json_object['proxynova']:
             p = ProxyIP(ip=ip_port['ip'], port=ip_port['port'])
             ip_list.append(p)
 


### PR DESCRIPTION
## Proposed Changes

  - Changed 'usproxy' to 'proxynova' since the [json file](https://raw.githubusercontent.com/sunny9577/proxy-scraper/master/proxies.json) has no 'usproxy' field. (#170 )
